### PR TITLE
Add the top option to retrieve a limited number of records

### DIFF
--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -497,6 +497,51 @@
 			"response": []
 		},
 		{
+			"name": "api/v1/models/{table name}?top={numer of records}",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/api/v1/models/m_product?top=2",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"m_product"
+					],
+					"query": [
+						{
+							"key": "top",
+							"value": "2"
+						}
+					]
+				},
+				"description": "Get a limited number of records from the given table."
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/models/{table name}?filter={where clause}",
 			"request": {
 				"method": "GET",

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
@@ -83,7 +83,7 @@ public interface ModelResource {
 	 * @return json array of records
 	 */
 	public Response getPOs(@PathParam("tableName") String tableName, @QueryParam("filter") String filter, @QueryParam("order") String order, 
-			@QueryParam("select") String select, @DefaultValue("0") @QueryParam("page_no") int pageNo);
+			@QueryParam("select") String select, @QueryParam("top") int top, @DefaultValue("0") @QueryParam("page_no") int pageNo);
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -50,6 +50,7 @@ import javax.xml.bind.DatatypeConverter;
 import org.compiere.model.MAttachment;
 import org.compiere.model.MAttachmentEntry;
 import org.compiere.model.MRole;
+import org.compiere.model.MSysConfig;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
@@ -80,7 +81,7 @@ import com.trekglobal.idempiere.rest.api.v1.resource.file.FileStreamingOutput;
 public class ModelResourceImpl implements ModelResource {
 
 	private static final int DEFAULT_QUERY_TIMEOUT = 60 * 2;
-	private static final int DEFAULT_PAGE_SIZE = 100;
+	private static final int MAX_PAGE_SIZE = MSysConfig.getIntValue("REST_MAX_PAGE_SIZE", 100);
 	private final static CLogger log = CLogger.getCLogger(ModelResourceImpl.class);
 
 	/**
@@ -209,8 +210,8 @@ public class ModelResourceImpl implements ModelResource {
 		query.setQueryTimeout(DEFAULT_QUERY_TIMEOUT);
 		int rowCount = query.count();
 		int pageCount = 1;
-		if (top > DEFAULT_PAGE_SIZE || top <= 0)
-			top = DEFAULT_PAGE_SIZE;
+		if (top > MAX_PAGE_SIZE || top <= 0)
+			top = MAX_PAGE_SIZE;
 
 		if (rowCount > top) {
 			pageCount = (int)Math.ceil(rowCount / (double)top);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -184,7 +184,7 @@ public class ModelResourceImpl implements ModelResource {
 	}
 
 	@Override
-	public Response getPOs(String tableName, String filter, String order, String select,  int pageNo) {
+	public Response getPOs(String tableName, String filter, String order, String select, int top, int pageNo) {
 		MTable table = MTable.get(Env.getCtx(), tableName);
 		if (table == null || table.getAD_Table_ID()==0)
 			return Response.status(Status.NOT_FOUND)
@@ -209,13 +209,16 @@ public class ModelResourceImpl implements ModelResource {
 		query.setQueryTimeout(DEFAULT_QUERY_TIMEOUT);
 		int rowCount = query.count();
 		int pageCount = 1;
-		if (rowCount > DEFAULT_PAGE_SIZE) {
-			pageCount = (int)Math.ceil(rowCount / (double)DEFAULT_PAGE_SIZE);
+		if (top > DEFAULT_PAGE_SIZE || top <= 0)
+			top = DEFAULT_PAGE_SIZE;
+
+		if (rowCount > top) {
+			pageCount = (int)Math.ceil(rowCount / (double)top);
 			if (pageNo <= 0)
 				pageNo = 1;
 			else if (pageNo > pageCount)
 				pageNo = pageCount;
-			query.setPage(DEFAULT_PAGE_SIZE, pageNo-1);			
+			query.setPage(top, pageNo-1);
 		} else {
 			pageNo = 1;
 		}
@@ -233,7 +236,7 @@ public class ModelResourceImpl implements ModelResource {
 			}
 			return Response.ok(array.toString())
 					.header("X-Page-Count", pageCount)
-					.header("X-Page-Size", DEFAULT_PAGE_SIZE)
+					.header("X-Page-Size", top)
 					.header("X-Page-Number", pageNo)
 					.header("X-Row-Count", rowCount)
 					.build();


### PR DESCRIPTION
Hi @hengsin, this adds the query option to request the number of items in the queried collection to be included in the result. It uses the top keyword as defined by odata.